### PR TITLE
Refactor version handling

### DIFF
--- a/.github/workflows/jars.yml
+++ b/.github/workflows/jars.yml
@@ -23,32 +23,10 @@ jobs:
         - uses: actions/checkout@v4
 
         - name: Download binaries
-          run: |
-            ./download-artifacts.rb -v ${{ inputs.openslide_version }}
+          run: ./download-artifacts.rb -v ${{ inputs.openslide_version }}
+
         - name: Process binaries into jars
-          shell: bash
-          run: |
-            mkdir -p build
-            pushd build
-            
-            mkdir -p darwin-aarch64 darwin-x86-64 linux-x86-64 win32-x86-64 linux-aarch64 licenses
-            cp ../artifacts/linux-x86_64/libopenslide.so linux-x86-64
-            cp ../artifacts/linux-aarch64/libopenslide.so linux-aarch64
-            cp ../artifacts/macos-arm64-x86_64/libopenslide.dylib darwin-aarch64
-            cp ../artifacts/macos-arm64-x86_64/libopenslide.dylib darwin-x86-64
-            cp ../artifacts/windows-x64/libopenslide*.dll win32-x86-64/openslide.dll
-            cp -r ../downloads/openslide-bin-*-linux-x86_64/licenses/* licenses
-            cp -r ../downloads/openslide-bin-*-macos-arm64-x86_64/licenses/* licenses
-            cp -r ../downloads/openslide-bin-*-windows-x64/licenses/* licenses
-            
-            jar cvf openslide-natives-darwin-aarch64.jar darwin-aarch64 licenses
-            jar cvf openslide-natives-darwin-x86-64.jar darwin-x86-64 licenses
-            jar cvf openslide-natives-linux-x86-64.jar linux-x86-64 licenses
-            jar cvf openslide-natives-linux-aarch64.jar linux-aarch64 licenses
-            jar cvf openslide-natives-win32-x86-64.jar win32-x86-64 licenses
-            jar cvf openslide-natives.jar linux-x86-64 linux-aarch64 darwin-x86-64 darwin-aarch64 win32-x86-64 licenses
-            
-            popd
+          run: process-artifacts.sh
 
         - uses: actions/upload-artifact@v4
           name: Upload jars

--- a/.github/workflows/jars.yml
+++ b/.github/workflows/jars.yml
@@ -1,24 +1,57 @@
 name: Create jars
 
 on:
-  - workflow_dispatch
-  - workflow_call
+  workflow_dispatch:
+    inputs:
+      openslide_version:
+        description: Semantic version of openslide binaries to download.
+        type: string
+        default: "4.0.0.6"
+        required: true
+  workflow_call:
+    inputs:
+      openslide_version:
+        description: Semantic version of openslide binaries to download.
+        type: string
+        default: "4.0.0.6"
+        required: true
 
 jobs:
-
   jars:
-
     runs-on: ubuntu-latest
-
     steps:
         - uses: actions/checkout@v4
 
-        - name: Download
-          run: ./download-artifacts.rb
-        - name: Process
-          run: ./process-artifacts.sh
+        - name: Download binaries
+          run: |
+            ./download-artifacts.rb -v ${{ inputs.openslide_version }}
+        - name: Process binaries into jars
+          shell: bash
+          run: |
+            mkdir -p build
+            pushd build
+            
+            mkdir -p darwin-aarch64 darwin-x86-64 linux-x86-64 win32-x86-64 linux-aarch64 licenses
+            cp ../artifacts/linux-x86_64/libopenslide.so linux-x86-64
+            cp ../artifacts/linux-aarch64/libopenslide.so linux-aarch64
+            cp ../artifacts/macos-arm64-x86_64/libopenslide.dylib darwin-aarch64
+            cp ../artifacts/macos-arm64-x86_64/libopenslide.dylib darwin-x86-64
+            cp ../artifacts/windows-x64/libopenslide*.dll win32-x86-64/openslide.dll
+            cp -r ../downloads/openslide-bin-*-linux-x86_64/licenses/* licenses
+            cp -r ../downloads/openslide-bin-*-macos-arm64-x86_64/licenses/* licenses
+            cp -r ../downloads/openslide-bin-*-windows-x64/licenses/* licenses
+            
+            jar cvf openslide-natives-darwin-aarch64.jar darwin-aarch64 licenses
+            jar cvf openslide-natives-darwin-x86-64.jar darwin-x86-64 licenses
+            jar cvf openslide-natives-linux-x86-64.jar linux-x86-64 licenses
+            jar cvf openslide-natives-linux-aarch64.jar linux-aarch64 licenses
+            jar cvf openslide-natives-win32-x86-64.jar win32-x86-64 licenses
+            jar cvf openslide-natives.jar linux-x86-64 linux-aarch64 darwin-x86-64 darwin-aarch64 win32-x86-64 licenses
+            
+            popd
 
         - uses: actions/upload-artifact@v4
+          name: Upload jars
           with:
             name: openslide-natives
             path: build/openslide-natives*.jar

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,19 +2,26 @@ name: Publish release to SciJava Maven
 
 on: 
   workflow_dispatch:
+    inputs:
+      openslide_version:
+        description: Semantic version of openslide binaries to download.
+        type: string
+        default: "4.0.0.6"
+        required: true
 
 jobs:
   jars:
     name: Build jars
     uses: ./.github/workflows/jars.yml
+    with:
+      openslide_version: inputs.openslide_version
   publish:
     needs: jars
     runs-on: ubuntu-latest
 
     steps:
-
     - uses: actions/checkout@v3
-    
+
     - uses: actions/download-artifact@v4
       with:
         merge-multiple: true  
@@ -31,7 +38,7 @@ jobs:
     - name: Publish snapshot
       uses: gradle/gradle-build-action@v2.4.2
       with:
-        arguments: publish -P release=true
+        arguments: publish -P release=true -P openslide_version=${{ inputs.openslide_version }}
       env:
         MAVEN_USER: ${{ secrets.MAVEN_USER }}
         MAVEN_PASS: ${{ secrets.MAVEN_PASS }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Publish snapshot
       uses: gradle/gradle-build-action@v2.4.2
       with:
-        arguments: publish -P release=true -P openslide_version=${{ inputs.openslide_version }}
+        arguments: publish -P release=true -P openslideVersion=${{ inputs.openslide_version }}
       env:
         MAVEN_USER: ${{ secrets.MAVEN_USER }}
         MAVEN_PASS: ${{ secrets.MAVEN_PASS }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Publish snapshot
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: publish -P openslide_version=${{ inputs.openslide_version }}-SNAPSHOT
+        arguments: publish -P openslideVersion=${{ inputs.openslide_version }}-SNAPSHOT
       env:
         MAVEN_USER: ${{ secrets.MAVEN_USER }}
         MAVEN_PASS: ${{ secrets.MAVEN_PASS }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Publish snapshot
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: publish -P openslide_version=${{ inputs.openslide_version }}
+        arguments: publish -P openslide_version=${{ inputs.openslide_version }}-SNAPSHOT
       env:
         MAVEN_USER: ${{ secrets.MAVEN_USER }}
         MAVEN_PASS: ${{ secrets.MAVEN_PASS }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,12 +1,20 @@
 name: Publish snapshot to SciJava Maven
 
 on: 
-  - workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      openslide_version:
+        description: Semantic version of openslide binaries to download.
+        type: string
+        default: "4.0.0.6"
+        required: true
 
 jobs:
   jars:
     name: Build jars
     uses: ./.github/workflows/jars.yml
+    with:
+      openslide_version: inputs.openslide_version
   publish:
     needs: jars
 
@@ -33,7 +41,7 @@ jobs:
     - name: Publish snapshot
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: publish
+        arguments: publish -P openslide_version=${{ inputs.openslide_version }}
       env:
         MAVEN_USER: ${{ secrets.MAVEN_USER }}
         MAVEN_PASS: ${{ secrets.MAVEN_PASS }}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'io.github.qupath'
-version = '4.0.0.6-SNAPSHOT'
+version = findProperty("openslideVersion") ?: "4.0.0.6"
 
 publishing {
     repositories {

--- a/download-artifacts.rb
+++ b/download-artifacts.rb
@@ -15,7 +15,7 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-target_release = options[:version] || "v4.0.0.6"
+target_release = options[:version] || "4.0.0.6"
 owner="openslide"
 repo="openslide-bin"
 `mkdir -p downloads artifacts`
@@ -37,7 +37,7 @@ end
 
 releases = JSON.parse(response.body)
 release = releases.find do |release|
-    release["tag_name"] == target_release
+    release["tag_name"] == "v#{target_release}"
 end
 
 
@@ -69,7 +69,7 @@ end.each do |asset|
 end
 
 platforms = ["linux-x86_64", "macos-arm64-x86_64", "windows-x64", "linux-aarch64"]
-version = target_release.sub("v", "")
+version = target_release
 platforms.each do |platform|
     `mkdir -p artifacts/#{platform}`
     `cp -rL downloads/openslide-bin-#{version}-#{platform}/lib/* artifacts/#{platform}/`

--- a/download-artifacts.rb
+++ b/download-artifacts.rb
@@ -15,7 +15,7 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-target_release = options[:version] || "4.0.0.6"
+version = options[:version] || "4.0.0.6"
 owner="openslide"
 repo="openslide-bin"
 `mkdir -p downloads artifacts`
@@ -37,7 +37,7 @@ end
 
 releases = JSON.parse(response.body)
 release = releases.find do |release|
-    release["tag_name"] == "v#{target_release}"
+    release["tag_name"] == "v#{version}"
 end
 
 
@@ -69,7 +69,6 @@ end.each do |asset|
 end
 
 platforms = ["linux-x86_64", "macos-arm64-x86_64", "windows-x64", "linux-aarch64"]
-version = target_release
 platforms.each do |platform|
     `mkdir -p artifacts/#{platform}`
     `cp -rL downloads/openslide-bin-#{version}-#{platform}/lib/* artifacts/#{platform}/`


### PR DESCRIPTION
Aims to simplify version handling in github actions by parameterising scripts where appropriate and passing between actions.

Release or snapshot builds can now be created without editing any files, simply running the github action with the relevant version (omitting -SNAPSHOT for snapshot builds!).